### PR TITLE
fixed issue-10

### DIFF
--- a/ffmpeg/0001-add-ism_offset-option-to-offset-fragment-start-times.patch
+++ b/ffmpeg/0001-add-ism_offset-option-to-offset-fragment-start-times.patch
@@ -1,7 +1,7 @@
-From f33e015c4b67322a1313ee48472d0bd1845d0bb4 Mon Sep 17 00:00:00 2001
-From: Mark Ogle <mark@unified-streaming.com>
-Date: Thu, 18 Jun 2020 12:00:03 +0200
-Subject: [PATCH 1/4] add -ism_offset option to offset fragment start times
+From 9ba97fa1fada43a22a597d41aad4de4c989c6dea Mon Sep 17 00:00:00 2001
+From: boby <glboby27@gmail.com>
+Date: Tue, 11 May 2021 20:51:33 -0700
+Subject: [PATCH 1/3] add-ism_offset-option-to-offset-fragment-start-times
 
 ---
  libavformat/movenc.c | 2 ++
@@ -9,7 +9,7 @@ Subject: [PATCH 1/4] add -ism_offset option to offset fragment start times
  2 files changed, 3 insertions(+)
 
 diff --git a/libavformat/movenc.c b/libavformat/movenc.c
-index 5d8dc4fd5d..5ffb7619ec 100644
+index 2ab507df15..ad49597845 100644
 --- a/libavformat/movenc.c
 +++ b/libavformat/movenc.c
 @@ -92,6 +92,7 @@ static const AVOption options[] = {
@@ -20,7 +20,7 @@ index 5d8dc4fd5d..5ffb7619ec 100644
      { "video_track_timescale", "set timescale of all video tracks", offsetof(MOVMuxContext, video_track_timescale), AV_OPT_TYPE_INT, {.i64 = 0}, 0, INT_MAX, AV_OPT_FLAG_ENCODING_PARAM},
      { "brand",    "Override major brand", offsetof(MOVMuxContext, major_brand),   AV_OPT_TYPE_STRING, {.str = NULL}, .flags = AV_OPT_FLAG_ENCODING_PARAM },
      { "use_editlist", "use edit list", offsetof(MOVMuxContext, use_editlist), AV_OPT_TYPE_BOOL, {.i64 = -1}, -1, 1, AV_OPT_FLAG_ENCODING_PARAM},
-@@ -6548,6 +6549,7 @@ static int mov_init(AVFormatContext *s)
+@@ -6575,6 +6576,7 @@ static int mov_init(AVFormatContext *s)
           * this is updated. */
          track->hint_track = -1;
          track->start_dts  = AV_NOPTS_VALUE;
@@ -29,7 +29,7 @@ index 5d8dc4fd5d..5ffb7619ec 100644
          track->end_pts    = AV_NOPTS_VALUE;
          track->dts_shift  = AV_NOPTS_VALUE;
 diff --git a/libavformat/movenc.h b/libavformat/movenc.h
-index 997b2d61c0..ebeddb6f0d 100644
+index af1ea0bce6..8680a1e32e 100644
 --- a/libavformat/movenc.h
 +++ b/libavformat/movenc.h
 @@ -203,6 +203,7 @@ typedef struct MOVMuxContext {
@@ -41,5 +41,5 @@ index 997b2d61c0..ebeddb6f0d 100644
  
      int video_track_timescale;
 -- 
-2.24.1 (Apple Git-126)
+2.25.1
 

--- a/ffmpeg/0002-add-audio_track_timescale-option.patch
+++ b/ffmpeg/0002-add-audio_track_timescale-option.patch
@@ -1,7 +1,7 @@
-From 4fbda4254936c30cac88125af999cc9449a9af5c Mon Sep 17 00:00:00 2001
-From: Mark Ogle <mark@unified-streaming.com>
-Date: Thu, 18 Jun 2020 12:17:10 +0200
-Subject: [PATCH 2/4] add audio_track_timescale option
+From ce51eb8b5459adb8c7c9c2e0fa5fd2f9f2f20d23 Mon Sep 17 00:00:00 2001
+From: boby <glboby27@gmail.com>
+Date: Tue, 11 May 2021 21:02:23 -0700
+Subject: [PATCH 2/3] add-audio_track_timescale-option
 
 ---
  libavformat/movenc.c | 15 ++++++++++++---
@@ -9,7 +9,7 @@ Subject: [PATCH 2/4] add audio_track_timescale option
  2 files changed, 13 insertions(+), 3 deletions(-)
 
 diff --git a/libavformat/movenc.c b/libavformat/movenc.c
-index 5ffb7619ec..8925475b19 100644
+index ad49597845..c6acbcebfe 100644
 --- a/libavformat/movenc.c
 +++ b/libavformat/movenc.c
 @@ -94,6 +94,7 @@ static const AVOption options[] = {
@@ -20,8 +20,8 @@ index 5ffb7619ec..8925475b19 100644
      { "brand",    "Override major brand", offsetof(MOVMuxContext, major_brand),   AV_OPT_TYPE_STRING, {.str = NULL}, .flags = AV_OPT_FLAG_ENCODING_PARAM },
      { "use_editlist", "use edit list", offsetof(MOVMuxContext, use_editlist), AV_OPT_TYPE_BOOL, {.i64 = -1}, -1, 1, AV_OPT_FLAG_ENCODING_PARAM},
      { "fragment_index", "Fragment number of the next fragment", offsetof(MOVMuxContext, fragments), AV_OPT_TYPE_INT, {.i64 = 1}, 1, INT_MAX, AV_OPT_FLAG_ENCODING_PARAM},
-@@ -6606,7 +6607,13 @@ static int mov_init(AVFormatContext *s)
-                 return AVERROR_PATCHWELCOME;
+@@ -6640,7 +6641,13 @@ static int mov_init(AVFormatContext *s)
+                     return AVERROR(ENOMEM);
              }
          } else if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO) {
 -            track->timescale = st->codecpar->sample_rate;
@@ -35,7 +35,7 @@ index 5ffb7619ec..8925475b19 100644
              if (!st->codecpar->frame_size && !av_get_bits_per_sample(st->codecpar->codec_id)) {
                  av_log(s, AV_LOG_WARNING, "track %d: codec frame size is not set\n", i);
                  track->audio_vbr = 1;
-@@ -6667,8 +6674,10 @@ static int mov_init(AVFormatContext *s)
+@@ -6701,8 +6708,10 @@ static int mov_init(AVFormatContext *s)
             doesn't mandate a track timescale of 10,000,000. The muxer allows a custom timescale
             for video tracks, so if user-set, it isn't overwritten */
          if (mov->mode == MODE_ISM &&
@@ -47,18 +47,19 @@ index 5ffb7619ec..8925475b19 100644
 +             (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO && !mov->video_track_timescale))) {
               track->timescale = 10000000;
          }
-
+ 
 diff --git a/libavformat/movenc.h b/libavformat/movenc.h
-index ebeddb6f0d..4a505800cd 100644
+index 8680a1e32e..532f066b22 100644
 --- a/libavformat/movenc.h
 +++ b/libavformat/movenc.h
 @@ -207,6 +207,7 @@ typedef struct MOVMuxContext {
      int first_trun;
-
+ 
      int video_track_timescale;
 +    int audio_track_timescale;
-
+ 
      int reserved_moov_size; ///< 0 for disabled, -1 for automatic, size otherwise
      int64_t reserved_header_pos;
---
-2.24.1 (Apple Git-126)
+-- 
+2.25.1
+

--- a/ffmpeg/0004-always-write-an-stss-box-in-CMAF-mode.patch
+++ b/ffmpeg/0004-always-write-an-stss-box-in-CMAF-mode.patch
@@ -1,17 +1,17 @@
-From 5d4c28abb037dd591900f53948f45d56dc8eac3d Mon Sep 17 00:00:00 2001
-From: Mark Ogle <mark@unified-streaming.com>
-Date: Thu, 18 Jun 2020 11:54:19 +0200
-Subject: [PATCH 4/4] always write an stss box in CMAF mode
+From dfdd9bd420f4e9c9b96891e5ea072b1cf9ddb2d3 Mon Sep 17 00:00:00 2001
+From: boby <glboby27@gmail.com>
+Date: Tue, 11 May 2021 21:04:12 -0700
+Subject: [PATCH 3/3] always-write-an-stss-box-in-CMAF-mode
 
 ---
  libavformat/movenc.c | 4 ++++
  1 file changed, 4 insertions(+)
 
 diff --git a/libavformat/movenc.c b/libavformat/movenc.c
-index 7cee522eac..7e9a8a8899 100644
+index c6acbcebfe..2f84b142ff 100644
 --- a/libavformat/movenc.c
 +++ b/libavformat/movenc.c
-@@ -2635,6 +2635,10 @@ static int mov_write_stbl_tag(AVFormatContext *s, AVIOContext *pb, MOVMuxContext
+@@ -2623,6 +2623,10 @@ static int mov_write_stbl_tag(AVFormatContext *s, AVIOContext *pb, MOVMuxContext
           track->par->codec_tag == MKTAG('r','t','p',' ')) &&
          track->has_keyframes && track->has_keyframes < track->entry)
          mov_write_stss_tag(pb, track, MOV_SYNC_SAMPLE);
@@ -23,5 +23,5 @@ index 7cee522eac..7e9a8a8899 100644
          mov_write_sdtp_tag(pb, track);
      if (track->mode == MODE_MOV && track->flags & MOV_TRACK_STPS)
 -- 
-2.24.1 (Apple Git-126)
+2.25.1
 

--- a/ffmpeg/Dockerfile
+++ b/ffmpeg/Dockerfile
@@ -72,7 +72,6 @@ RUN     DIR=$(mktemp -d) && cd ${DIR} && \
         --enable-libfontconfig \
         --enable-libfreetype \
         --enable-gpl \
-        --enable-avresample \
         --enable-postproc \
         --enable-nonfree \
         --disable-debug \


### PR DESCRIPTION
Updated patch files to match up with a new ffmpeg version.
Remove the deprecated option (--enable-avresample) in ffmpeg.