### PR TITLE
Use audio and video codec from streams settings

### DIFF
--- a/ffmpeg/entrypoint.py
+++ b/ffmpeg/entrypoint.py
@@ -213,7 +213,7 @@ for video in tracks["video"]:
     command.append([
         "-map", f"[v{count}]",
         "-s", f"{video['width']}x{video['height']}",
-        "-c:v", "libx264",
+        "-c:v", str(video["codec"])
         "-b:v", video["bitrate"],
         "-profile:v", "main",
         "-preset", "ultrafast",
@@ -231,7 +231,7 @@ for audio in tracks["audio"]:
     count += 1
     command.append([
         "-map", f"[a{count}]",
-        "-c:a", "aac",
+        "-c:a", str(audio["codec"]),
         "-b:a", str(audio["bitrate"]),
         "-ar", str(audio["samplerate"]),
         "-metadata:s:a:0", f"language={audio['language']}",


### PR DESCRIPTION
I was used this project to create a ingest for a HEVC + EAC3 Live stream but the audio and video codec were hardcoded at the python script.

Also, I had to add the 'delay_moov' flag to the MOVFLAGS variable, but I am not sure if this ok for you.